### PR TITLE
[ADD]: paso al taller 2 y 3

### DIFF
--- a/taller2-acceso-puertos.md
+++ b/taller2-acceso-puertos.md
@@ -42,7 +42,15 @@ ifconfig -a
 ```
 y buscar el IP público o bien con el IP público asignado por tu proveedor de la nube, solo debes acceder desde el navegador como
 ```
-http://IP:8001
+http://IP:PORT
+```
+Para acceder desde el host:
+```
+http://IP_HOST:8001
+```
+Para acceder desde el container:
+```
+http://IP_CONTAINER:80
 ```
 y podrás ver la instalación por defecto de Apache, también puedes usar el puerto 80 en el servidor público, colocando -p 80:80 en vez de -p 8001:80
 ## Paso 4: Ver IP del container

--- a/taller3-dockerfiles.md
+++ b/taller3-dockerfiles.md
@@ -40,6 +40,8 @@ EXPOSE 80  El puerto que expone del container será el 80
 ## Paso 2: Construir imagen y subirla a DockerHub para que sea pública
 Para poder construir una imagen a partir de un Dockerfile, primero debemos ubicarnos en la carpeta que tiene el Dockerfile en este caso taller3-source, luego ejecutamos los siguientes comandos:
 
+En caso de no tener cuenta de docker hub, acceda a [Docker Hub](https://hub.docker.com/) y cree una.
+
 Primero nos logueamos con docker login, ingresando nuestro usuario y contraseña creados en el DockerHub:
 ```
 docker login 


### PR DESCRIPTION
taller 2: se agrego el paso que explica como acceder al pagina por defecto de apache ubuntu desde el container y desde el host.

taller 3: se agrego paso que advierte que hacer en caso de no tener cuenta de docker hub.